### PR TITLE
Add compatibility with Pyside2/Qt5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 *.pyc
 resources.py

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,0 +1,144 @@
+###############################################
+Setup sigrok-meter on Python 3 with PySide2/Qt5
+###############################################
+
+
+************
+Introduction
+************
+
+This documentation outlines how to install ``sigrok-meter`` on a
+contemporary Linux or macOS machine. Please read it carefully.
+
+Using a virtualenv to install ``sigrok-meter`` is considered best practice.
+There are two variants:
+
+1. Install PyGObject 3 for your Linux/macOS distribution Python.
+   When using this variant, please use the ``--system-site-packages`` option
+   to ``virtualenv``.
+
+2. Install PyGObject 3 using ``pip``.
+   When using this variant, you are completely isolated from the distribution
+   Python, but you will need ``libffi`` instead. As this will need
+   ``libffi >= 3.0``, there is a line how to tweak ``PKG_CONFIG_PATH`` to
+   use a contemporary version provided by Homebrew. On a different environment,
+   you might well omit that line.
+
+
+***********
+Get sources
+***********
+
+::
+
+    git clone https://github.com/sigrokproject/sigrok-meter
+    cd sigrok-meter
+
+
+*********************
+Install prerequisites
+*********************
+
+This section will guide you through installing PyGObject version 3,
+the Python bindings to GLib.
+
+Variant 1
+=========
+
+This uses the PyGObject package from your distribution Python.
+::
+
+    # Install PyGObject 3.
+    brew install pygobject3
+    apt-get install python3-gi
+
+    # Create and activate virtualenv.
+    virtualenv .venv39 --python=python3.9 --system-site-packages
+    source .venv39/bin/activate
+
+
+Variant 2
+=========
+
+This installs PyGObject using ``pip``.
+::
+
+    # Install libffi.
+    brew install libffi
+    apt-get install libffi6
+
+    # Create and activate virtualenv.
+    virtualenv .venv39 --python=python3.9
+    source .venv39/bin/activate
+
+    # Install PyGObject 3, needs libffi >= 3.0.
+    export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+    pip install pygobject
+
+
+********************
+Install sigrok-meter
+********************
+
+This section illustrates how to populate the virtualenv with the prerequisites
+needed for running ``sigrok-meter``.
+
+
+libsigrok Python binding
+========================
+
+This assumes you successfully compiled ``libsigrok`` including its Python
+bindings like::
+
+    ../configure --enable-bindings --enable-cxx --enable-ruby=false --enable-java=false
+
+Here we go::
+
+    # Activate virtualenv.
+    source .venv39/bin/activate
+
+    # Install libsigrok Python binding. YMMV.
+    pip install numpy
+    python -m easy_install /path/to/libsigrok/build/bindings/python/dist/libsigrok-0.6.0-py3.9-macosx-10.13-x86_64.egg
+
+Two additional notes:
+
+1. You should install the same version of NumPy used when building ``libsigrok``.
+2. If ``easy_install`` is missing on your machine, you might want to decide to
+   downgrade ``setuptools`` within your virtualenv to the most recent version
+   still including it by typing ``pip install "setuptools~=51.3"``.
+
+
+Finally
+=======
+
+This will install the PySide2/Qt5 bindings and will instruct you how to compile
+the Qt resource file into a Python representation, see also
+`.qrc Files » Generating a Python file`_.
+
+.. _.qrc Files » Generating a Python file: https://doc.qt.io/qtforpython/tutorials/basictutorial/qrcfiles.html#generating-a-python-file
+
+::
+
+    # Activate virtualenv.
+    source .venv39/bin/activate
+
+    # Install UI prerequisites.
+    pip install pyside2 pyqtgraph
+
+    # Sanity checks.
+    ./test
+
+    # Compile resources from "resources.qrc".
+    make
+
+
+*********
+Testdrive
+*********
+
+Run ``sigrok-meter``::
+
+    ./sigrok-meter --pyside --driver demo:analog_channels=1 --config samplerate=10:limit_samples=10
+
+Enjoy.

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,21 @@ ifneq ($(MAKECMDGOALS),clean)
     ifeq (0,$(shell which pyside-rcc >/dev/null 2>&1; echo $$?))
       RCC = pyside-rcc
     else
-      $(error "resource compiler not found")
+      ifeq (0,$(shell which pyside2-rcc >/dev/null 2>&1; echo $$?))
+        RCC = pyside2-rcc
+      else
+        $(error "resource compiler not found")
+      endif
     endif
   endif
 endif
 
 resources.py: resources.qrc
+ifeq ($(RCC),pyside2-rcc)
+	$(RCC) -o $@ $<
+else
 	$(RCC) -py3 -o $@ $<
+endif
 
 .PHONY: clean
 clean:

--- a/acquisition.py
+++ b/acquisition.py
@@ -24,6 +24,7 @@ import sigrok.core as sr
 import time
 
 QtCore = qtcompat.QtCore
+QtWidgets = qtcompat.QtWidgets
 
 class Acquisition(QtCore.QObject):
     '''Class that handles the sigrok session and the reception of data.'''
@@ -114,6 +115,7 @@ class Acquisition(QtCore.QObject):
     def start(self):
         '''Start the session.'''
         self.session.start()
+        self.session.run()
 
     @QtCore.Slot()
     def stop(self):
@@ -138,6 +140,14 @@ class Acquisition(QtCore.QObject):
 
         self.measured.emit(now, device, channel,
                 (value, packet.payload.unit, packet.payload.mq_flags))
+
+        # Process pending events to keep the UI responsive.
+        # The most basic solution is to explicitly ask Qt to process pending
+        # events at some point in the computation. To do this, you have to
+        # call `QCoreApplication::processEvents()` periodically.
+        # https://doc.qt.io/archives/qq/qq27-responsive-guis.html#manualeventprocessing
+        # https://doc.qt.io/qt-5/qcoreapplication.html#processEvents
+        QtWidgets.QApplication.processEvents()
 
     def _stopped_callback(self, **kwargs):
         self.stopped.emit()

--- a/acquisition.py
+++ b/acquisition.py
@@ -98,13 +98,13 @@ class Acquisition(QtCore.QObject):
 
         device = devs[0]
 
+        self.session.add_device(device)
+        device.open()
+
         # Process configuration string.
         cfgs = self._parse_configstring(configstring)
         for k, v in cfgs.items():
             device.config_set(sr.ConfigKey.get_by_identifier(k), v)
-
-        self.session.add_device(device)
-        device.open()
 
     def is_running(self):
         '''Return whether the session is running.'''

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -69,7 +69,7 @@ class MainWindow(QtGui.QMainWindow):
         self.context = context
         self.drivers = drivers
 
-        self.logModel = QtGui.QStringListModel(self)
+        self.logModel = QtCore.QStringListModel(self)
         self.context.set_log_callback(self._log_callback)
 
         self.delegate = datamodel.MultimeterDelegate(self, self.font())

--- a/qtcompat.py
+++ b/qtcompat.py
@@ -21,8 +21,8 @@ import sys
 
 def load_modules(force_pyside):
     if force_pyside:
-        import PySide.QtCore as _QtCore
-        import PySide.QtGui as _QtGui
+        import PySide2.QtCore as _QtCore
+        import PySide2.QtGui as _QtGui
     else:
         try:
             # Use version 2 API in all cases, because that's what PySide uses.
@@ -44,8 +44,8 @@ def load_modules(force_pyside):
             _QtCore.Slot = _QtCore.pyqtSlot
         except:
             sys.stderr.write('Import of PyQt4 failed, using PySide,\n')
-            import PySide.QtCore as _QtCore
-            import PySide.QtGui as _QtGui
+            import PySide2.QtCore as _QtCore
+            import PySide2.QtGui as _QtGui
 
     global QtCore
     global QtGui

--- a/qtcompat.py
+++ b/qtcompat.py
@@ -23,6 +23,7 @@ def load_modules(force_pyside):
     if force_pyside:
         import PySide2.QtCore as _QtCore
         import PySide2.QtGui as _QtGui
+        import PySide2.QtWidgets as _QtWidgets
     else:
         try:
             # Use version 2 API in all cases, because that's what PySide uses.
@@ -46,11 +47,14 @@ def load_modules(force_pyside):
             sys.stderr.write('Import of PyQt4 failed, using PySide,\n')
             import PySide2.QtCore as _QtCore
             import PySide2.QtGui as _QtGui
+            import PySide2.QtWidgets as _QtWidgets
 
     global QtCore
     global QtGui
+    global QtWidgets
     QtCore = _QtCore
     QtGui = _QtGui
+    QtWidgets = _QtWidgets
 
     import pyqtgraph as _pyqtgraph
     import pyqtgraph.dockarea as _pyqtgraph_dockarea


### PR DESCRIPTION
Dear Uwe, Jens and all sigrok contributors,

first things first: Thanks a stack for conceiving and maintaining sigrok.

While we know PulseView and SmuView are in the focus of development, there might still be a need for `sigrok-meter`. A friend told me that he would be interested to run `sigrok-meter` on Python 3. So, I tried to look into that and after finding it would still be based on PySide/Qt4, I decided to give it a shot to check what it would take to modernize it to use PySide2/Qt5. It turned out that it was not too much.

So, while I don't know if this is an accepted method to hand in patches to the code base, I still wanted to publish it here. Let me know what you think about it and also if you have a different process of submitting patches.

Keep up the spirit and with kind regards,
Andreas.
